### PR TITLE
On error while creating tasks, report the offending task.

### DIFF
--- a/doit/loader.py
+++ b/doit/loader.py
@@ -217,17 +217,19 @@ def load_tasks(namespace, command_names=(), allow_delayed=False, args=(),
                 creator_kwargs, _ = parser.parse('')
         else:
             creator_kwargs = {}
-
-        if not delayed:  # not a delayed task, just run creator
-            _process_gen(ref, creator_kwargs)
-        elif delayed.creates:  # delayed with explicit task basename
-            for tname in delayed.creates:
-                _add_delayed(tname, ref, delayed, creator_kwargs)
-        elif allow_delayed:  # delayed no explicit name, cmd run
-            _add_delayed(name, ref, delayed, creator_kwargs)
-        else:  # delayed no explicit name, cmd list (run creator)
-            _process_gen(ref, creator_kwargs)
-
+        try:
+            if not delayed:  # not a delayed task, just run creator
+                _process_gen(ref, creator_kwargs)
+            elif delayed.creates:  # delayed with explicit task basename
+                for tname in delayed.creates:
+                    _add_delayed(tname, ref, delayed, creator_kwargs)
+            elif allow_delayed:  # delayed no explicit name, cmd run
+                _add_delayed(name, ref, delayed, creator_kwargs)
+            else:  # delayed no explicit name, cmd list (run creator)
+                _process_gen(ref, creator_kwargs)
+        except Exception as e:
+            raise RuntimeError("Exception occurred while trying to create the task '"+name+"'") from e            
+            
     return task_list
 
 


### PR DESCRIPTION
This is especially applicable if tasks are defined using the create_doit_tasks() function mechanism, which can have more complicated instructions and cause errors. If the exception further occurs in a function that cannot be assigned to a task (e.g. a helper function in use by multiple tasks), having the task name in the error message is helpful.

I am not sure what kind of error to raise, since the doit-internal "exceptions" like `TaskError` are not derived
from `BaseException`, so they cannot be used with `raise`.